### PR TITLE
krux-installer v0.0.1-beta revision 2f0ee130

### DIFF
--- a/.github/workflows/build-windows-nsis.yml
+++ b/.github/workflows/build-windows-nsis.yml
@@ -24,12 +24,12 @@ jobs:
         shell: pwsh
         run: |
           $loc = Get-Location
-          $firmware_version = "v22.08.2"
+          $firmware_version = "v23.09.0"
           $zipname = "krux-$firmware_version.zip"
           $signame = "krux-$firmware_version.zip.sig"
           $pemname = "selfcustody.pem"
           $extraResources = "$loc\extraResources"
-          $opensslVersion = "3.1.1"
+          $opensslVersion = "3.1.3"
           $release_url = "https://github.com/selfcustody/krux/releases/download"
           $raw_url = "https://raw.githubusercontent.com/selfcustody/krux/main"
           $app_version = node -e "console.log(require('./package.json').version)"
@@ -128,7 +128,7 @@ jobs:
       - name: Install chromedriver.exe
         shell: pwsh
         run: |
-          $url = "https://chromedriver.storage.googleapis.com/114.0.5735.90/chromedriver_win32.zip"
+          $url = "https://chromedriver.storage.googleapis.com/106.0.5249.61/chromedriver_win32.zip"
           $tmp_path = ".\chromedriver_win32.zip"
           $dest_path = "node_modules\chromedriver\bin"
           Invoke-WebRequest -Uri $url -OutFile $tmp_path

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,8 @@ name: Build
 on:
   push:
     branches: 
-      - main
+      #- main
+      - fix-macs
     paths-ignore:
       - "**.md"
       #- "**.spec.js"
@@ -17,15 +18,15 @@ on:
 
 jobs:
 
-  build-linux-appimage:
-    uses: ./.github/workflows/build-linux-appimage.yml
-    secrets: 
-      token: ${{ secrets.github_token }}
+  #build-linux-appimage:
+  #  uses: ./.github/workflows/build-linux-appimage.yml
+  #  secrets: 
+  #    token: ${{ secrets.github_token }}
 
-  build-windows-nsis:
-    uses: ./.github/workflows/build-windows-nsis.yml 
-    secrets: 
-      token: ${{ secrets.github_token }}
+  #build-windows-nsis:
+  #  uses: ./.github/workflows/build-windows-nsis.yml 
+  #  secrets: 
+  #    token: ${{ secrets.github_token }}
 
   build-mac-dmg:
     uses: ./.github/workflows/build-mac-dmg.yml 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,7 @@ name: Build
 on:
   push:
     branches: 
-      #- main
-      - fix-macs
+      - main
     paths-ignore:
       - "**.md"
       #- "**.spec.js"
@@ -18,15 +17,15 @@ on:
 
 jobs:
 
-  #build-linux-appimage:
-  #  uses: ./.github/workflows/build-linux-appimage.yml
-  #  secrets: 
-  #    token: ${{ secrets.github_token }}
+  build-linux-appimage:
+    uses: ./.github/workflows/build-linux-appimage.yml
+    secrets: 
+      token: ${{ secrets.github_token }}
 
-  #build-windows-nsis:
-  #  uses: ./.github/workflows/build-windows-nsis.yml 
-  #  secrets: 
-  #    token: ${{ secrets.github_token }}
+  build-windows-nsis:
+    uses: ./.github/workflows/build-windows-nsis.yml 
+    secrets: 
+      token: ${{ secrets.github_token }}
 
   build-mac-dmg:
     uses: ./.github/workflows/build-mac-dmg.yml 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/png" href="/icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline';" />
-    <title>KruxInstaller v0.0.1-alpha-5</title>
+    <title><%= title %></title>
   </head>
   <body>
     <div id="app"></div>

--- a/lib/app.ts
+++ b/lib/app.ts
@@ -188,7 +188,7 @@ export default class App extends Base {
 
     app.on('activate', () => {
       this.log('Checking existence of other windows')
-      const allWindows =  Electron.BrowserWindow.getAllWindows()
+      const allWindows = BrowserWindow.getAllWindows()
       if (allWindows.length) {
         allWindows[0].focus()
       } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "krux-installer",
-  "version": "0.0.1-alpha-6",
+  "version": "0.0.1-beta",
+  "revision": "5690dd35", 
   "main": "dist-electron/main/index.js",
   "description": "Graphical User Interface to download, verify and flash Krux´s firmware on Kendryte K210 hardwares as bitcoin signature devices",
   "author": "qlrd <106913782+qlrd@users.noreply.github.com>",
@@ -35,7 +36,8 @@
     "build": "vue-tsc --noEmit && vite build && electron-builder",
     "preview": "vite preview",
     "e2e": "wdio run wdio.conf.mts",
-    "lint:md": "markdownlint README.md --ignore node_modules"
+    "lint:md": "markdownlint README.md --ignore node_modules",
+    "make:revision": "sha256sum yarn.lock | cut -c -8"
   },
   "devDependencies": {
     "@babel/cli": "^7.22.9",
@@ -54,7 +56,7 @@
     "@wdio/mocha-framework": "^8.12.1",
     "@wdio/spec-reporter": "^8.12.2",
     "chai": "^4.3.7",
-    "electron": "^26.2.1",
+    "electron": "^26.2.2",
     "electron-builder": "^24.4.0",
     "glob": "^10.3.3",
     "markdownlint-cli": "^0.36.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "krux-installer",
   "version": "0.0.1-beta",
-  "revision": "5690dd35", 
+  "revision": "2f0ee130",
   "main": "dist-electron/main/index.js",
   "description": "Graphical User Interface to download, verify and flash Krux´s firmware on Kendryte K210 hardwares as bitcoin signature devices",
   "author": "qlrd <106913782+qlrd@users.noreply.github.com>",
@@ -59,7 +59,7 @@
     "electron": "^26.2.2",
     "electron-builder": "^24.4.0",
     "glob": "^10.3.3",
-    "markdownlint-cli": "^0.36.0",
+    "markdownlint-cli": "^0.37.0",
     "mocha": "^10.2.0",
     "os-lang": "^3.1.1",
     "rimraf": "^5.0.1",
@@ -68,6 +68,7 @@
     "vite": "^4.4.6",
     "vite-plugin-electron": "^0.14.1",
     "vite-plugin-electron-renderer": "^0.14.1",
+    "vite-plugin-html": "^3.2.0",
     "vue": "^3.2.47",
     "vue-tsc": "^1.8.6",
     "wdio-electron-service": "^4.3.0"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,8 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vuetify from 'vite-plugin-vuetify'
 import electron from 'vite-plugin-electron'
+import { createHtmlPlugin } from 'vite-plugin-html'
+
 
 //import renderer from 'vite-plugin-electron-renderer'
 import pkg from './package.json'
@@ -65,7 +67,15 @@ export default defineConfig(({ command }) => {
             },
           }
         }
-      ])
+      ]),
+      createHtmlPlugin({
+        minify: true,
+        inject: {
+          data: {
+            title: `${pkg.name} ${pkg.version}${pkg.revision !== '' ? '.' + pkg.revision : ''}`
+          }
+        }
+      })
     ],
     server: process.env.VSCODE_DEBUG && (() => {
       const url = new URL(pkg.vscode.debug.env.VITE_DEV_SERVER_URL)


### PR DESCRIPTION
### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [ ] Documentation update
- [x] Other

### Description

Major update:

- Changed to [`electron v26.2.2`](https://releases.electronjs.org/release/v26.2.2);
- Windows usage of [`openssl v3.1.3`](https://github.com/openssl/openssl/releases/tag/openssl-3.1.3).

Minor update: 

- Fixed how version is show at window header.

### Changelog

- [Removed class Electron from Electron.BrowserWindow](https://github.com/selfcustody/krux-installer/commit/90e35ab14f263fc947d0cfe00ef3e255230c484a)
- [Changed version to beta](https://github.com/selfcustody/krux-installer/commit/c6ac1f84ee6a08e770b074c004829fbf8245d29d)
- [Added vite-plugin-html to dynamic header on top of window](https://github.com/selfcustody/krux-installer/commit/4a30bf374a0d33aed885e133ec5445df7f1f5d23)
- [Updated windows build workflows](https://github.com/selfcustody/krux-installer/commit/889e0369b703d4ef0f5cf223250b2b5816fa1899)


### Warning

Many thanks to infinite1 from telegram group for patience to test MacOS release even with bugs in execution, that can still show the following errors during flash (which were not possible to reproduce since I do not have an apple machine):

```bash
Error: 0:336: execution error: [1047] Cannot open PyInstaller archive from executable (/Users/user/Documents/krux-installer/krux-v23.09.0/ktool-mac) or external archive (/Users/user/Documents/krux-installer/krux-v23.09.0/ktool-mac.pkg) (255)

    at Socket. (/Applications/krux-installer.app/Contents/Resources/app.asar/dist-electron/main/index.js:6:381)
    at Socket.emit (node:events:513:28)
    at addChunk (node:internal/streams/readable:324:12)
    at readableAddChunk (node:internal/streams/readable:297:9)
    at Socket.push (node:internal/streams/readable:234:10)
    at Pipe.onStreamRead (node:internal/stream_base_commons:190:23)
```

And an GUI Alert Warning which I tried to mitigate in this PR:

```bash
A Javascript error occurred in the main process

Uncaught Exception:

Reference error: Electron is not defined

  at App.<anonymous>(/Applications/krux-installer.app/Contents/Resources/app.asar/dist-electron/main/index.js:1:3753)
  at App.emit (node:events:513:28)
```