### PR TITLE
v0.0.20-alpha-3

### DIFF
--- a/e2e/test_008_about_screen.py
+++ b/e2e/test_008_about_screen.py
@@ -42,7 +42,7 @@ class TestAboutScreen(GraphicUnitTest):
 
         text = "".join(
             [
-                "[ref=SourceCode][b]v0.0.20-alpha-2[/b][/ref]",
+                "[ref=SourceCode][b]v0.0.20-alpha-3[/b][/ref]",
                 "\n",
                 "\n",
                 "follow us on X: ",
@@ -80,7 +80,7 @@ class TestAboutScreen(GraphicUnitTest):
 
         text = "".join(
             [
-                "[ref=SourceCode][b]v0.0.20-alpha-2[/b][/ref]",
+                "[ref=SourceCode][b]v0.0.20-alpha-3[/b][/ref]",
                 "\n",
                 "\n",
                 "siga-nos no X: ",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ prefer-active-python = true
 
 [tool.poetry]
 name = "krux-installer"
-version = "0.0.20-alpha-2"
+version = "0.0.20-alpha-3"
 description = "A GUI based application to flash Krux firmware on K210 based devices"
 authors = [
   "qlrd <qlrddev@gmail.com>"

--- a/src/app/screens/select_device_screen.py
+++ b/src/app/screens/select_device_screen.py
@@ -98,7 +98,11 @@ class SelectDeviceScreen(BaseScreen):
                 ):
                     cleanre = re.compile("\\[.*?\\]")
                     clean_text = re.sub(cleanre, "", value)
-                    if device not in VALID_DEVICES_VERSIONS[clean_text]:
+                    if (
+                        # pylint: disable=consider-iterating-dictionary
+                        clean_text in VALID_DEVICES_VERSIONS.keys()
+                        and device not in VALID_DEVICES_VERSIONS[clean_text]
+                    ):
                         self.ids[f"select_device_{device}"].text = "".join(
                             ["[color=#333333]", device, "[/color]"]
                         )

--- a/src/utils/constants/__init__.py
+++ b/src/utils/constants/__init__.py
@@ -33,6 +33,7 @@ import os
 ROOT_DIRNAME = os.path.abspath(os.path.dirname(__file__))
 
 VALID_DEVICES_VERSIONS = {
+    "v24.09.1": ["m5stickv", "amigo", "dock", "bit", "yahboom", "cube", "wonder_mv"],
     "v24.09.0": ["m5stickv", "amigo", "dock", "bit", "yahboom", "cube", "wonder_mv"],
     "v24.07.0": ["m5stickv", "amigo", "dock", "bit", "yahboom", "cube"],
     "v24.03.0": ["m5stickv", "amigo", "dock", "bit", "yahboom"],


### PR DESCRIPTION
This release fix:

- When a new firmware version is added, the hard coded ones with `VALID_DEVICES_VERSIONS` will make Installer crash;

- The fix suggested by @odudex to manage new versions (good when a hot fix is made) in line 101 of `src/app/screens/select_device_screen.py`;
