### PR TITLE
Increase Delay Between Requests

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -4,3 +4,7 @@ coverage:
       default:
         target: 95%
         threshold: 5%
+    patch:
+      default:
+        target: 95%
+        threshold: 5%

--- a/.pylint/src
+++ b/.pylint/src
@@ -287,9 +287,6 @@ ignored-parents=
 # Maximum number of arguments for function / method.
 max-args=10
 
-# Maximum number of positional arguments
-max-positional-arguments=10
-
 # Maximum number of attributes for a class (see R0902).
 max-attributes=20
 

--- a/.pylint/tests
+++ b/.pylint/tests
@@ -287,9 +287,6 @@ ignored-parents=
 # Maximum number of arguments for function / method.
 max-args=10
 
-# Maximum number of positional arguments
-max-positional-arguments=10
-
 # Maximum number of attributes for a class (see R0902).
 max-attributes=7
 
@@ -304,6 +301,9 @@ max-locals=15
 
 # Maximum number of parents for a class (see R0901).
 max-parents=7
+
+# Maximum number of positional arguments for function / method.
+max-positional-arguments=10
 
 # Maximum number of public methods for a class (see R0904).
 max-public-methods=20

--- a/e2e/test_011_download_stable_zip_sha256_screen.py
+++ b/e2e/test_011_download_stable_zip_sha256_screen.py
@@ -325,3 +325,28 @@ class TestDownloadStableZipSha256Screen(GraphicUnitTest):
         mock_set_screen.assert_called_once_with(
             name="DownloadStableZipSigScreen", direction="left"
         )
+
+    @patch.object(EventLoopBase, "ensure_window", lambda x: None)
+    @patch(
+        "src.app.screens.base_screen.BaseScreen.get_locale", return_value="en_US.UTF-8"
+    )
+    @patch("src.app.screens.download_stable_zip_sha256_screen.time.sleep")
+    @patch("src.app.screens.base_download_screen.BaseDownloadScreen.on_pre_enter")
+    def test_on_pre_enter(self, mock_super_on_pre_enter, mock_sleep, mock_get_locale):
+        screen = DownloadStableZipSha256Screen()
+        self.render(screen)
+
+        # get your Window instance safely
+        EventLoop.ensure_window()
+
+        # Call on_pre_enter
+        screen.on_pre_enter()
+
+        # Verify time.sleep was called with 3 seconds
+        mock_sleep.assert_called_once_with(3)
+
+        # Verify parent's on_pre_enter was called
+        mock_super_on_pre_enter.assert_called_once()
+
+        # patch assertions
+        mock_get_locale.assert_any_call()

--- a/e2e/test_012_download_stable_zip_sig_screen.py
+++ b/e2e/test_012_download_stable_zip_sig_screen.py
@@ -320,3 +320,28 @@ class TestDownloadStableZipSigScreen(GraphicUnitTest):
         mock_set_screen.assert_called_once_with(
             name="DownloadSelfcustodyPemScreen", direction="left"
         )
+
+    @patch.object(EventLoopBase, "ensure_window", lambda x: None)
+    @patch(
+        "src.app.screens.base_screen.BaseScreen.get_locale", return_value="en_US.UTF-8"
+    )
+    @patch("src.app.screens.download_stable_zip_sig_screen.time.sleep")
+    @patch("src.app.screens.base_download_screen.BaseDownloadScreen.on_pre_enter")
+    def test_on_pre_enter(self, mock_super_on_pre_enter, mock_sleep, mock_get_locale):
+        screen = DownloadStableZipSigScreen()
+        self.render(screen)
+
+        # get your Window instance safely
+        EventLoop.ensure_window()
+
+        # Call on_pre_enter
+        screen.on_pre_enter()
+
+        # Verify time.sleep was called with 3 seconds
+        mock_sleep.assert_called_once_with(3)
+
+        # Verify parent's on_pre_enter was called
+        mock_super_on_pre_enter.assert_called_once()
+
+        # patch assertions
+        mock_get_locale.assert_any_call()

--- a/e2e/test_013_download_selfcustody_pem_screen.py
+++ b/e2e/test_013_download_selfcustody_pem_screen.py
@@ -305,3 +305,28 @@ class TestDownloadSelfcustodyPemScreen(GraphicUnitTest):
         mock_set_screen.assert_called_once_with(
             name="VerifyStableZipScreen", direction="left"
         )
+
+    @patch.object(EventLoopBase, "ensure_window", lambda x: None)
+    @patch(
+        "src.app.screens.base_screen.BaseScreen.get_locale", return_value="en_US.UTF-8"
+    )
+    @patch("src.app.screens.download_selfcustody_pem_screen.time.sleep")
+    @patch("src.app.screens.base_download_screen.BaseDownloadScreen.on_pre_enter")
+    def test_on_pre_enter(self, mock_super_on_pre_enter, mock_sleep, mock_get_locale):
+        screen = DownloadSelfcustodyPemScreen()
+        self.render(screen)
+
+        # get your Window instance safely
+        EventLoop.ensure_window()
+
+        # Call on_pre_enter
+        screen.on_pre_enter()
+
+        # Verify time.sleep was called with 3 seconds
+        mock_sleep.assert_called_once_with(3)
+
+        # Verify parent's on_pre_enter was called
+        mock_super_on_pre_enter.assert_called_once()
+
+        # patch assertions
+        mock_get_locale.assert_any_call()

--- a/src/app/screens/base_screen.py
+++ b/src/app/screens/base_screen.py
@@ -206,6 +206,7 @@ class BaseScreen(Screen, Trigger):
         on_release: typing.Callable | None,
         on_ref_press: typing.Callable | None,
     ):
+        # pylint: disable=too-many-positional-arguments
         """Create buttons in a dynamic way"""
         self.debug(f"button::{wid} row={row}")
 
@@ -421,6 +422,7 @@ class BaseScreen(Screen, Trigger):
         allowed_screens: typing.Tuple,
         on_update: typing.Callable | None,
     ):
+        # pylint: disable=too-many-positional-arguments
         """
         Update a screen in accord with the valid ones, here or in on_update callback
         """

--- a/src/app/screens/download_selfcustody_pem_screen.py
+++ b/src/app/screens/download_selfcustody_pem_screen.py
@@ -68,6 +68,12 @@ class DownloadSelfcustodyPemScreen(BaseDownloadScreen):
         fn = partial(self.update, name=self.name, key="canvas")
         Clock.schedule_once(fn, 0)
 
+    # pylint: disable=unused-argument
+    def on_pre_enter(self, *args):
+        """Before enter, add delay to avoid GitHub rate limiting"""
+        time.sleep(3)
+        super().on_pre_enter(*args)
+
     def on_update_pem(self):
         """Update public key certificate on GUI"""
         self.downloader = PemDownloader(

--- a/src/app/screens/download_stable_zip_sha256_screen.py
+++ b/src/app/screens/download_stable_zip_sha256_screen.py
@@ -75,6 +75,12 @@ class DownloadStableZipSha256Screen(BaseDownloadScreen):
         Clock.schedule_once(fn, 0)
 
     # pylint: disable=unused-argument
+    def on_pre_enter(self, *args):
+        """Before enter, add delay to avoid GitHub rate limiting"""
+        time.sleep(3)
+        super().on_pre_enter(*args)
+
+    # pylint: disable=unused-argument
     def update(self, *args, **kwargs):
         """Update screen with version key. Should be called before `on_enter`"""
         name = str(kwargs.get("name"))

--- a/src/app/screens/download_stable_zip_sig_screen.py
+++ b/src/app/screens/download_stable_zip_sig_screen.py
@@ -70,6 +70,12 @@ class DownloadStableZipSigScreen(BaseDownloadScreen):
         Clock.schedule_once(fn, 0)
 
     # pylint: disable=unused-argument
+    def on_pre_enter(self, *args):
+        """Before enter, add delay to avoid GitHub rate limiting"""
+        time.sleep(3)
+        super().on_pre_enter(*args)
+
+    # pylint: disable=unused-argument
     def update(self, *args, **kwargs):
         """Update screen with version key. Should be called before `on_enter`"""
         name = str(kwargs.get("name"))

--- a/src/app/screens/greetings_screen.py
+++ b/src/app/screens/greetings_screen.py
@@ -28,8 +28,10 @@ from kivy.clock import Clock
 from src.utils.selector import Selector
 from src.app.screens.base_screen import BaseScreen
 
-if sys.platform.startswith("linux"):
+try:
     import grp
+except ImportError:
+    grp = None  # grp is only available on Unix systems
 
 
 class GreetingsScreen(BaseScreen):
@@ -165,6 +167,10 @@ class GreetingsScreen(BaseScreen):
     def is_user_in_dialout_group(self, user: str, group: str):
         """Check if the provided user is in dialout"""
         _in_dialout = False
+
+        # grp module is only available on Unix systems
+        if "grp" not in globals() or grp is None:
+            return _in_dialout
 
         # loop throug all linux groups and check
         # if the user is registered in the "dialout" group

--- a/src/app/screens/greetings_screen.py
+++ b/src/app/screens/greetings_screen.py
@@ -28,11 +28,6 @@ from kivy.clock import Clock
 from src.utils.selector import Selector
 from src.app.screens.base_screen import BaseScreen
 
-try:
-    import grp
-except ImportError:
-    grp = None  # grp is only available on Unix systems
-
 
 class GreetingsScreen(BaseScreen):
     """GreetingsScreen show Krux logo"""
@@ -169,12 +164,14 @@ class GreetingsScreen(BaseScreen):
         _in_dialout = False
 
         # grp module is only available on Unix systems
-        if "grp" not in globals() or grp is None:
+        try:
+            import grp  # pylint: disable=import-outside-toplevel
+        except ImportError:
+            # grp not available (e.g., on Windows)
             return _in_dialout
 
         # loop throug all linux groups and check
         # if the user is registered in the "dialout" group
-        # pylint: disable=possibly-used-before-assignment
         for _grp in grp.getgrall():
             gr_name = _grp.gr_name
             if gr_name == group:

--- a/tests/test_006_stream_downloader.py
+++ b/tests/test_006_stream_downloader.py
@@ -233,6 +233,7 @@ class TestStreamDownloader(TestCase):
                 },
                 timeout=30,
             )
+
     @patch("src.utils.downloader.stream_downloader.time.sleep", return_value=None)
     @patch("src.utils.downloader.stream_downloader.requests")
     def test_rate_limit_retry_then_success(self, mock_requests, mock_sleep):

--- a/tests/test_006_stream_downloader.py
+++ b/tests/test_006_stream_downloader.py
@@ -185,3 +185,51 @@ class TestStreamDownloader(TestCase):
             sd.download_file_stream(url="https://any.request/test.zip")
 
         self.assertEqual(str(exc_info.exception), "Download connection error: None")
+
+    @patch("src.utils.downloader.stream_downloader.time.sleep", return_value=None)
+    @patch("src.utils.downloader.stream_downloader.requests")
+    def test_fail_rate_limit_exceeded_download_file_stream(
+        self, mock_requests, mock_sleep
+    ):
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        mock_response.headers = {"Content-Length": "210000"}
+
+        http_error = requests.exceptions.HTTPError()
+        http_error.response = mock_response
+        mock_response.raise_for_status.side_effect = http_error
+
+        mock_requests.exceptions = requests.exceptions
+        mock_requests.get.return_value = mock_response
+
+        max_retries = 2
+
+        with self.assertRaises(RuntimeError) as exc_info:
+            sd = StreamDownloader(url=URL)
+            setattr(sd, "on_data", MagicMock())
+            sd.download_file_stream(
+                url="https://any.request/test429.zip", max_retries=max_retries
+            )
+
+        self.assertEqual(str(exc_info.exception), "HTTP error 429: None")
+
+        expected_attempts = 1 + max_retries
+        self.assertEqual(mock_requests.get.call_count, expected_attempts)
+
+        self.assertEqual(mock_sleep.call_count, max_retries)
+
+        expected_sleep_calls = [call(2**i) for i in range(1, max_retries + 1)]
+        mock_sleep.assert_has_calls(expected_sleep_calls)
+
+        for i in range(expected_attempts):
+            mock_requests.get.assert_any_call(
+                url="https://any.request/test429.zip",
+                stream=True,
+                headers={
+                    "Content-Disposition": "attachment filename=test429.zip",
+                    "Connection": "keep-alive",
+                    "Cache-Control": "max-age=0",
+                    "Accept-Encoding": "gzip, deflate, br",
+                },
+                timeout=30,
+            )

--- a/tests/test_006_stream_downloader.py
+++ b/tests/test_006_stream_downloader.py
@@ -185,3 +185,84 @@ class TestStreamDownloader(TestCase):
             sd.download_file_stream(url="https://any.request/test.zip")
 
         self.assertEqual(str(exc_info.exception), "Download connection error: None")
+
+    @patch("src.utils.downloader.stream_downloader.time.sleep", return_value=None)
+    @patch("src.utils.downloader.stream_downloader.requests")
+    def test_fail_rate_limit_exceeded_download_file_stream(
+        self, mock_requests, mock_sleep
+    ):
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        mock_response.headers = {"Content-Length": "210000"}
+
+        http_error = requests.exceptions.HTTPError()
+        http_error.response = mock_response
+        mock_response.raise_for_status.side_effect = http_error
+
+        mock_requests.exceptions = requests.exceptions
+        mock_requests.get.return_value = mock_response
+
+        max_retries = 2
+
+        with self.assertRaises(RuntimeError) as exc_info:
+            sd = StreamDownloader(url=URL)
+            setattr(sd, "on_data", MagicMock())
+            sd.download_file_stream(
+                url="https://any.request/test429.zip", max_retries=max_retries
+            )
+
+        self.assertEqual(str(exc_info.exception), "HTTP error 429: None")
+
+        expected_attempts = 1 + max_retries
+        self.assertEqual(mock_requests.get.call_count, expected_attempts)
+
+        self.assertEqual(mock_sleep.call_count, max_retries)
+
+        expected_sleep_calls = [call(2**i) for i in range(1, max_retries + 1)]
+        mock_sleep.assert_has_calls(expected_sleep_calls)
+
+        for i in range(expected_attempts):
+            mock_requests.get.assert_any_call(
+                url="https://any.request/test429.zip",
+                stream=True,
+                headers={
+                    "Content-Disposition": "attachment filename=test429.zip",
+                    "Connection": "keep-alive",
+                    "Cache-Control": "max-age=0",
+                    "Accept-Encoding": "gzip, deflate, br",
+                },
+                timeout=30,
+            )
+    @patch("src.utils.downloader.stream_downloader.time.sleep", return_value=None)
+    @patch("src.utils.downloader.stream_downloader.requests")
+    def test_rate_limit_retry_then_success(self, mock_requests, mock_sleep):
+        mock_response_429 = MagicMock()
+        mock_response_429.status_code = 429
+        http_error = requests.exceptions.HTTPError()
+        http_error.response = mock_response_429
+        mock_response_429.raise_for_status.side_effect = http_error
+        mock_response_200 = MagicMock()
+        mock_response_200.status_code = 200
+        mock_response_200.headers = {"Content-Length": "210000"}
+        mock_response_200.iter_content.return_value = [[b"test", b"data"]]
+        mock_response_200.raise_for_status.return_value = None
+
+        mock_requests.get.side_effect = [
+            mock_response_429,
+            mock_response_429,
+            mock_response_200,
+        ]
+        mock_requests.exceptions = requests.exceptions
+
+        sd = StreamDownloader(url=URL)
+        setattr(sd, "on_data", MagicMock())
+
+        sd.download_file_stream(url="https://any.call/test.zip", max_retries=5)
+
+        self.assertEqual(mock_requests.get.call_count, 3)
+
+        self.assertEqual(mock_sleep.call_count, 2)
+        expected_sleep_calls = [call(2), call(4)]
+        mock_sleep.assert_has_calls(expected_sleep_calls)
+
+        self.assertEqual(sd.content_len, 210000)


### PR DESCRIPTION
To avoid "Too Many Requests" error while downloading Github assets, increase delay between requests and try download multiple times with exponential delay between attempts.