### PR TITLE
fix: update outdated packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,9 @@ prefer-active-python = true
 
 [tool.poetry]
 name = "krux_installer"
-version = "0.0.22"
+version = "0.0.21"
 description = "A GUI based application to flash Krux firmware on K210 based devices"
-authors = [
-  "qlrd <qlrddev@gmail.com>"
-]
+authors = ["qlrd <qlrddev@gmail.com>"]
 license = "LICENSE"
 readme = "README.md"
 
@@ -23,7 +21,7 @@ opencv-python = "^4.12.0.88"
 cryptography = "^44.0.3"
 qrcode = "^8.2"
 easy-i18n = "^1.2.0"
-pysudoer = {git = "https://github.com/qlrd/pysudoer.git"}
+pysudoer = { git = "https://github.com/qlrd/pysudoer.git" }
 pillow = "^11.3.0"
 pyinstaller = "^6.16.0"
 olefile = "^0.47"
@@ -38,12 +36,18 @@ demjson3 = "^3.0.6"
 
 [tool.poe.tasks]
 cli = "python src/krux_installer.py"
-format-src= "black ./src"
-format-tests= "black ./tests"
-format-e2e= "black ./e2e"
-format-drives= "black ./e2e_drives"
+format-src = "black ./src"
+format-tests = "black ./tests"
+format-e2e = "black ./e2e"
+format-drives = "black ./e2e_drives"
 format-installer = "black ./krux_installer.py"
-format = ["format-src", "format-tests", "format-e2e", "format-drives", "format-installer"]
+format = [
+  "format-src",
+  "format-tests",
+  "format-e2e",
+  "format-drives",
+  "format-installer",
+]
 
 test-unit = "pytest --cache-clear --cov=src/utils/constants --cov=src/utils/info --cov=src/utils/selector --cov=src/utils/downloader --cov=src/utils/trigger --cov=src/utils/flasher --cov=src/utils/unzip --cov=src/utils/signer --cov=src/utils/verifyer --cov=src/i18n --cov-branch --cov-report html ./tests"
 test-e2e = "pytest --cov-append --cov=src/app --cov-branch --cov-report html ./e2e"
@@ -56,31 +60,34 @@ coverage-drives = "pytest --cov-append --cov=src/app --cov-branch --cov-report x
 coverage = ["coverage-unit", "coverage-e2e", "coverage-drives"]
 
 lint.sequence = [
-  { cmd = "jsonlint src/i18n/*.json"},
+  { cmd = "jsonlint src/i18n/*.json" },
   { cmd = "pylint --rcfile=.pylint/src ./src" },
-  { cmd = "pylint --rcfile=.pylint/tests ./tests"},
-  { cmd = "pylint --rcfile=.pylint/tests ./e2e"},
-  { cmd = "pylint --rcfile=.pylint/tests ./e2e_drives"}
+  { cmd = "pylint --rcfile=.pylint/tests ./tests" },
+  { cmd = "pylint --rcfile=.pylint/tests ./e2e" },
+  { cmd = "pylint --rcfile=.pylint/tests ./e2e_drives" },
 ]
 
 build-linux.sequence = [
   { cmd = "sh .ci/patch-pyinstaller-kivy-hook.sh" },
-  { cmd = "python .ci/create-spec.py"},
-  { cmd = "python -m PyInstaller krux-installer.spec"}
+  { cmd = "python .ci/create-spec.py" },
+  { cmd = "python -m PyInstaller krux-installer.spec" },
 ]
 
 build-macos.sequence = [
   { cmd = "find . -name '.DS_Store' -delete" },
   { cmd = "sh .ci/patch-pyinstaller-kivy-hook.sh" },
-  { cmd = "python .ci/create-spec.py"},
-  { cmd = "python -m PyInstaller krux-installer.spec"}
+  { cmd = "python .ci/create-spec.py" },
+  { cmd = "python -m PyInstaller krux-installer.spec" },
 ]
 
 build-win.sequence = [
   { cmd = "powershell.exe -File .ci/patch-pyinstaller-kivy-hook.ps1" },
-  { cmd = "python .ci/create-spec.py"},
-  { interpreter = ["powershell", "pwsh"], shell = "& .ci/edit-spec.ps1"},
-  { cmd = "python -m PyInstaller krux-installer.spec"}
+  { cmd = "python .ci/create-spec.py" },
+  { interpreter = [
+    "powershell",
+    "pwsh",
+  ], shell = "& .ci/edit-spec.ps1" },
+  { cmd = "python -m PyInstaller krux-installer.spec" },
 ]
 
 [tool.poe.tasks.dev-debug]


### PR DESCRIPTION
Mainly kivy, cryptography, black and poethe poet.

Other updates are subdependencies from these.

Added "--no-root" option to "poetry install" command on "Install poetry dependencies" in tests and build workflows