### PR TITLE
fix: replace `typing.re` for `typing.Pattern`

### DIFF
--- a/src/utils/verifyer/check_verifyer.py
+++ b/src/utils/verifyer/check_verifyer.py
@@ -32,7 +32,12 @@ from .base_verifyer import BaseVerifyer
 class CheckVerifyer(BaseVerifyer):
     """basic class for *CheckVerifyer class (do not use directly)"""
 
-    def __init__(self, filename: str, read_mode: str, regexp: typing.re):
+    def __init__(
+        self,
+        filename: str,
+        read_mode: str,
+        regexp: typing.Union[str, typing.Pattern[str]],
+    ):
         if not re.findall(regexp, filename):
             raise ValueError(f"Invalid file: {filename} do not assert with {regexp}")
 

--- a/src/utils/verifyer/sig_verifyer.py
+++ b/src/utils/verifyer/sig_verifyer.py
@@ -30,9 +30,15 @@ from .check_verifyer import CheckVerifyer
 
 
 class SigVerifyer(CheckVerifyer):
-    """Verify file signature agains .sig and .pem data"""
+    """Verify file signature against .sig and .pem data"""
 
-    def __init__(self, filename: str, signature: str, pubkey: str, regexp: typing.re):
+    def __init__(
+        self,
+        filename: str,
+        signature: bytes,
+        pubkey: str,
+        regexp: typing.Union[str, typing.Pattern[str]],
+    ):
         super().__init__(filename=filename, read_mode="rb", regexp=regexp)
         self.certificate = serialization.load_pem_public_key(pubkey)
         self.signature = signature


### PR DESCRIPTION
This commit replaces the two places where a regular expression was typed as `typing.re` by `typing.Pattern`.