### PR TITLE
ci: add conventional commits to krux-installer

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,13 @@
+name: Conventional Commits
+
+on:
+  pull_request: # We only need to check commit messages in PRs
+
+jobs:
+  conventional-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: webiny/action-conventional-commits@v1.3.0
+        with:
+          allowed-commit-types: "feat,fix,docs,style,refactor,test,i18n,ci,chore"


### PR DESCRIPTION
Convetional commits are a specification for adding human and machine readable meaning to commit messages. This commit checks if the follow-up commits agree with those specified in the
https://www.conventionalcommits.org/en/v1.0.0/. While this changes some of the current workflow for commits, this brings more organization and a development standard (the semmantic git commit message) to a project that had a lot of attention in the last months.