### PR TITLE
chore(pylint): comment the unsupported `suggestion-mode` option

### DIFF
--- a/.pylint/src
+++ b/.pylint/src
@@ -101,7 +101,7 @@ source-roots=
 
 # When enabled, pylint would attempt to guess common misconfiguration and emit
 # user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
+# suggestion-mode=yes
 
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.

--- a/.pylint/tests
+++ b/.pylint/tests
@@ -101,7 +101,7 @@ source-roots=
 
 # When enabled, pylint would attempt to guess common misconfiguration and emit
 # user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
+# suggestion-mode=yes
 
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.


### PR DESCRIPTION
This commit comment the `suggestion-mode` option, before supported, but not anymore in `pylint==^4.0.4`, in bot `.pylint/src` and `.pylint/test` files.