### PR TITLE
ci: add yamllint to poe tasks and protect CI files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,34 +25,86 @@ jobs:
           filters: |
             change:
               - 'LICENSE'
-            
+              - 'AGENT.md'
+              - 'CLAUDE.md'
+              - 'SECURITY.md'
+              - 'CHANGELOG.md'
+              - 'CONTRIBUTING.md'
+              - '.github/workflows/*.yml'
+              - 'pyproject.toml'
+              - 'poetry.lock'
+
       # ref: https://github.com/github/docs/blob/main/.github/workflows/triage-unallowed-contributions.yml
       - name: Comment About Changes We Can't Accept
         if: ${{ steps.filter_not_allowed.outputs.change == 'true' }}
         uses: actions/github-script@v8
+        id: filter_author_permissions
         with:
           script: |
-            let workflowFailMessage = "It looks like you've modified some files that we can't accept as contributions."
-            try {
-              const badFilesArr = [
-                'LICENSE'  
-              ]
-              const badFiles = badFilesArr.join('\n- ')
-              const reviewMessage = `👋 Hey there kruxer. It looks like you've modified some files that we can't accept as contributions. The complete list of files we can't accept are:\n- ${badFiles}\n\nYou'll need to revert all of the files you changed in that list using [GitHub Desktop](https://docs.github.com/en/free-pro-team@latest/desktop/contributing-and-collaborating-using-github-desktop/managing-commits/reverting-a-commit) or \`git checkout origin/main <file name>\`. Once you get those files reverted, we can continue with the review process. :octocat:`
-              createdComment = await github.rest.issues.createComment({
+            let workflowFailMessage = [
+              "It looks like you've modified some files",
+              "that we can't accept as contributions."
+            ];
+            workflowFailMessage = workflowFailMessage.join(' ');
+            try
+            {
+              const badFilesArr = ${{ steps.filter_not_allowed.outputs.change_files }};
+              const goodAuthorsArr = [
+                'jdlcdl',
+                'joaozinhom',
+                'odudex',
+                'qlrd',
+                'tadeubas'
+              ];
+
+              for (let i in goodAuthorsArr)
+              {
+                const author = goodAuthorsArr[i];
+                if (author === '${{ github.actor }}')
+                {
+                  return;
+                }
+              }
+
+              const badFiles = badFilesArr.join(';\n- ');
+              const reviewMessage = `👋 Hey there ${{ github.actor }}.
+
+                It looks like you've modified some files that we can't accept
+                as contributions. The complete list of files we can't accept
+                are:
+
+                - ${badFiles}
+
+                You'll need to revert and edit or rebase your changes. Once you
+                get those files reverted, we can continue with the review
+                process.:octocat:`;
+
+              const createdComment = await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.payload.number,
                 body: reviewMessage,
-              })
-              workflowFailMessage = `${workflowFailMessage} Please see ${createdComment.data.html_url} for details.`
+              });
+
+              workflowFailMessage = `${workflowFailMessage}
+
+             Please see ${createdComment.data.html_url} for details.`;
+
+              core.setFailed(workflowFailMessage);
             } catch(err) {
-              console.log("Error creating comment.", err)
+              workflowFailMessage = `${workflowFailMessage}
+
+              We failed in something, it's not your fault, but you
+              will need to retrigger with \`git commit --amend --no-edit\` and
+              \`git push --force-with-lease\`:
+
+              ${err.toString()}`;
+
+              core.setFailed(workflowFailMessage);
             }
-            core.setFailed(workflowFailMessage)
 
       - name: Check Not Linted Markdown
-        if: ${{ always() }}
+        if: ${{ steps.filter_author_permissions.outcome != 'failure' }}
         uses: dorny/paths-filter@v4
         id: filter_markdown
         with:
@@ -66,7 +118,7 @@ jobs:
     name: Lint Markdown
     runs-on: ubuntu-latest
     needs: job1
-    if: ${{ always() && needs.job1.outputs.markdown_change == 'true' }}
+    if: ${{ needs.job1.outputs.markdown_change == 'true' }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,8 @@ coverage-e2e = "pytest --cov-append --cov=src/app --cov-branch --cov-report xml 
 coverage-drives = "pytest --cov-append --cov=src/app --cov-branch --cov-report xml ./e2e_drives"
 coverage = ["coverage-unit", "coverage-e2e", "coverage-drives"]
 
+lint-yaml = "python -m yamllint -d '{extends: default, rules: {line-length: {max: 120}, truthy: disable, document-start: disable}}' .github/workflows/"
+
 lint.sequence = [
   { cmd = "jsonlint src/i18n/*.json" },
   { cmd = "pylint --rcfile=.pylint/src ./src" },


### PR DESCRIPTION
- Add `lint-yaml` poe task to run yamllint on workflow files;
- Add `.github/workflows/*.yml`, `pyproject.toml`, and `poetry.lock` to the not-allowed file changes filter;
- Fix yamllint issues in `ci.yml`: trailing whitespace, extra colon spacing.

Used claude to review and help to fix the diff.