### PR TITLE
fix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      
-  - package-ecosystem: "pip"
+
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Fix accidental removal of Dependabot compatibility introduced in https://github.com/selfcustody/krux-installer/pull/215.