### PR TITLE
feat(ci): add structured logging and build verbosity control

### DIFF
--- a/.ci/build.py
+++ b/.ci/build.py
@@ -83,19 +83,18 @@ _TERMINAL_LEVELS = {"ERROR", "CRITICAL"}
 _VALID_LEVELS = {"TRACE", "DEBUG", "INFO", "WARN", "WARNING", "ERROR", "CRITICAL"}
 _VERBOSE_LEVELS = {"TRACE", "DEBUG"}
 
-_NOISE_PATTERNS = [
-    re.compile(r"Spelling.*Unable to find any valuable Spelling provider", re.IGNORECASE),
-    re.compile(r"enchant.*ModuleNotFoundError", re.IGNORECASE),
-    re.compile(r"osxappkit.*ModuleNotFoundError", re.IGNORECASE),
-    re.compile(r"DEPRECATION.*Onefile mode.*macOS", re.IGNORECASE),
-    re.compile(r"Library libmtdev", re.IGNORECASE),
-    re.compile(r"Library setupapi", re.IGNORECASE),
-    re.compile(r"Library Cfgmgr32", re.IGNORECASE),
-    re.compile(r"Library Advapi32", re.IGNORECASE),
-    re.compile(r"Ignoring.*IOKit.*only basenames are supported", re.IGNORECASE),
-    re.compile(r"Ignoring.*CoreFoundation.*only basenames are supported", re.IGNORECASE),
-    re.compile(r"Could not find GStreamer", re.IGNORECASE),
-]
+_NOISE_PATTERN = re.compile(
+    r"|".join([
+        r"Spelling.*Unable to find any valuable Spelling provider",
+        r"enchant.*ModuleNotFoundError",
+        r"osxappkit.*ModuleNotFoundError",
+        r"DEPRECATION.*Onefile mode.*macOS",
+        r"Library (libmtdev|setupapi|Cfgmgr32|Advapi32)",
+        r"Ignoring.*(IOKit|CoreFoundation).*only basenames are supported",
+        r"Could not find GStreamer",
+    ]),
+    re.IGNORECASE,
+)
 
 _PATTERN = re.compile(
     r"^\s*(?:\d+\s+)?"
@@ -166,7 +165,7 @@ def _detect_level(line: str) -> str:
 
 
 def _is_noise(line: str) -> bool:
-    return any(p.search(line) for p in _NOISE_PATTERNS)
+    return _NOISE_PATTERN.search(line)
 
 
 def _make_json_entry(level: str, message: str) -> str:

--- a/.ci/build.py
+++ b/.ci/build.py
@@ -1,0 +1,261 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2021-2026 Krux contributors
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+.ci/build.py
+
+Runs PyInstaller as a subprocess, captures all output, routes each line
+to the appropriate log file under logs/, and keeps the terminal clean.
+
+Terminal output:
+  - Default (WARN): spinner — only real fatal errors shown inline
+  - --loglevel=TRACE or DEBUG: every line printed, no spinner
+
+Disk output (logs/ directory, one JSON-lines file per level):
+  - logs/trace.log  — everything
+  - logs/debug.log  — DEBUG and above
+  - logs/info.log   — INFO and above
+  - logs/warn.log   — WARN and above
+  - logs/error.log  — ERROR and CRITICAL only
+
+Usage:
+    python .ci/build.py                    # silent terminal, logs/ on disk
+    python .ci/build.py --loglevel=INFO    # INFO+ in terminal + logs/
+    python .ci/build.py --loglevel=DEBUG   # DEBUG+ in terminal + logs/
+    python .ci/build.py --loglevel=TRACE   # everything in terminal + logs/
+"""
+
+import argparse
+import json
+import os
+import platform
+import re
+import subprocess
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent.absolute()
+LOGS_DIR = ROOT / "logs"
+SPEC_FILE = "krux-installer.spec"
+
+_LEVEL_PRIORITY = {
+    "TRACE": 0,
+    "DEBUG": 10,
+    "INFO": 20,
+    "WARN": 30,
+    "WARNING": 30,
+    "DEPRECATION": 30,
+    "ERROR": 40,
+    "CRITICAL": 50,
+}
+
+_LOG_FILES = [
+    ("trace", 0),
+    ("debug", 10),
+    ("info", 20),
+    ("warn", 30),
+    ("error", 40),
+]
+
+_TERMINAL_LEVELS = {"ERROR", "CRITICAL"}
+
+_VALID_LEVELS = {"TRACE", "DEBUG", "INFO", "WARN", "WARNING", "ERROR", "CRITICAL"}
+_VERBOSE_LEVELS = {"TRACE", "DEBUG"}
+
+_NOISE_PATTERNS = [
+    re.compile(r"Spelling.*Unable to find any valuable Spelling provider", re.IGNORECASE),
+    re.compile(r"enchant.*ModuleNotFoundError", re.IGNORECASE),
+    re.compile(r"osxappkit.*ModuleNotFoundError", re.IGNORECASE),
+    re.compile(r"DEPRECATION.*Onefile mode.*macOS", re.IGNORECASE),
+    re.compile(r"Library libmtdev", re.IGNORECASE),
+    re.compile(r"Library setupapi", re.IGNORECASE),
+    re.compile(r"Library Cfgmgr32", re.IGNORECASE),
+    re.compile(r"Library Advapi32", re.IGNORECASE),
+    re.compile(r"Ignoring.*IOKit.*only basenames are supported", re.IGNORECASE),
+    re.compile(r"Ignoring.*CoreFoundation.*only basenames are supported", re.IGNORECASE),
+    re.compile(r"Could not find GStreamer", re.IGNORECASE),
+]
+
+_PATTERN = re.compile(
+    r"^\s*(?:\d+\s+)?"
+    r"(TRACE|DEBUG|INFO|WARN|WARNING|DEPRECATION|ERROR|CRITICAL|FATAL)"
+    r"[\s:\]]+",
+    re.IGNORECASE,
+)
+
+if platform.system() == "Windows":
+    _SPINNER_FRAMES = ["-", "\\", "|", "/"]
+    _CHECK = "[OK]"
+    _CROSS = "[FAILED]"
+else:
+    _SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+    _CHECK = "✓"
+    _CROSS = "✗"
+
+class Spinner:
+    def __init__(self, message: str = "Building krux-installer"):
+        self._message = message
+        self._stop_event = threading.Event()
+        self._thread = threading.Thread(target=self._spin, daemon=True)
+
+    def start(self):
+        self._thread.start()
+
+    def stop(self, success: bool = True):
+        self._stop_event.set()
+        self._thread.join()
+        sys.stdout.write("\r" + " " * (len(self._message) + 4) + "\r")
+        sys.stdout.flush()
+        if success:
+            print(f"{_CHECK} Build complete.")
+        else:
+            print(f"{_CROSS} Build failed.", file=sys.stderr)
+
+    def _spin(self):
+        idx = 0
+        while not self._stop_event.is_set():
+            frame = _SPINNER_FRAMES[idx % len(_SPINNER_FRAMES)]
+            sys.stdout.write(f"\r{frame} {self._message}...")
+            sys.stdout.flush()
+            time.sleep(0.1)
+            idx += 1
+
+def _parse_args() -> str:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument(
+        "--loglevel",
+        default=os.environ.get("BUILD_LOGLEVEL", "WARN"),
+        choices=list(_VALID_LEVELS),
+        type=str.upper,
+    )
+    args, _ = parser.parse_known_args()
+    return args.loglevel
+
+
+def _detect_level(line: str) -> str:
+    m = _PATTERN.match(line)
+    if m:
+        lvl = m.group(1).upper()
+        if lvl == "FATAL":
+            return "CRITICAL"
+        if lvl == "WARNING":
+            return "WARN"
+        return lvl
+    return "INFO"
+
+
+def _is_noise(line: str) -> bool:
+    return any(p.search(line) for p in _NOISE_PATTERNS)
+
+
+def _make_json_entry(level: str, message: str) -> str:
+    return json.dumps(
+        {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "level": level,
+            "message": message.rstrip(),
+        },
+        ensure_ascii=False,
+    )
+
+
+def _open_log_files(logs_dir: Path) -> dict:
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    handles = {}
+    for name, priority in _LOG_FILES:
+        handles[priority] = open(logs_dir / f"{name}.log", "a", encoding="utf-8")
+    return handles
+
+
+def _write_to_logs(handles: dict, level: str, line: str) -> None:
+    line_priority = _LEVEL_PRIORITY.get(level, 20)
+    entry = _make_json_entry(level, line)
+    for file_priority, fh in handles.items():
+        if line_priority >= file_priority:
+            fh.write(entry + "\n")
+            fh.flush()
+
+
+def _close_log_files(handles: dict) -> None:
+    for fh in handles.values():
+        fh.close()
+
+if __name__ == "__main__":
+    build_loglevel = _parse_args()
+    verbose = build_loglevel in _VERBOSE_LEVELS
+
+    handles = _open_log_files(LOGS_DIR)
+
+    spinner = None
+    if not verbose:
+        spinner = Spinner()
+        spinner.start()
+    else:
+        print(f"[build] Starting PyInstaller — log level: {build_loglevel}")
+
+    process = subprocess.Popen(
+        [sys.executable, "-m", "PyInstaller", SPEC_FILE],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env={**os.environ, "KIVY_NO_CONSOLELOG": "1"},
+    )
+
+    try:
+        for raw_line in process.stdout:
+            line = raw_line.rstrip()
+            if not line:
+                continue
+
+            level = _detect_level(line)
+            noise = _is_noise(line)
+
+            _write_to_logs(handles, level, line)
+
+            if verbose:
+                print(line)
+            elif level in _TERMINAL_LEVELS and not noise:
+                if spinner:
+                    sys.stdout.write("\r" + " " * 60 + "\r")
+                    sys.stdout.flush()
+                print(line, file=sys.stderr)
+
+    finally:
+        process.wait()
+        _close_log_files(handles)
+
+    success = process.returncode == 0
+
+    if spinner:
+        spinner.stop(success=success)
+
+    if not success:
+        print(
+            f"Check {LOGS_DIR.relative_to(ROOT)}/error.log for details.",
+            file=sys.stderr,
+        )
+
+    sys.exit(process.returncode)

--- a/.ci/clean.py
+++ b/.ci/clean.py
@@ -1,0 +1,62 @@
+# The MIT License (MIT)
+
+# Copyright (c) 2021-2026 Krux contributors
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+.ci/clean.py
+
+Cross-platform cleanup of build artifacts. Removes:
+  - build/
+  - dist/
+  - logs/
+  - krux-installer.spec
+
+Usage:
+  uv run poe clean
+"""
+
+import shutil
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent.absolute()
+
+TARGETS = [
+    ROOT / "build",
+    ROOT / "dist",
+    ROOT / "logs",
+    ROOT / "krux-installer.spec",
+]
+
+
+def clean() -> None:
+    for target in TARGETS:
+        if target.exists():
+            if target.is_dir():
+                shutil.rmtree(target)
+                print(f"removed dir  {target.relative_to(ROOT)}")
+            else:
+                target.unlink()
+                print(f"removed file {target.relative_to(ROOT)}")
+        else:
+            print(f"skip (not found) {target.relative_to(ROOT)}")
+
+
+if __name__ == "__main__":
+    clean()

--- a/.ci/create-spec.py
+++ b/.ci/create-spec.py
@@ -20,10 +20,24 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 """
-build.py
+create-spec.py
+
+Generates the PyInstaller .spec file for krux-installer.
+
+Terminal output is controlled by the BUILD_LOGLEVEL environment variable,
+set automatically by the poe build tasks via the --debug flag:
+
+    poetry run poe build-macos              # silent (default: WARN)
+    poetry run poe build-macos --debug=INFO # prints spec args summary
+    poetry run poe build-macos --debug=DEBUG  # prints spec args summary
+    poetry run poe build-macos --debug=TRACE  # prints spec args summary
+
+Allowed values: TRACE | DEBUG | INFO | WARN | ERROR | CRITICAL
 """
 
 import argparse
+import os
+import sys
 from os import listdir
 from os.path import isfile, join
 from pathlib import Path
@@ -33,6 +47,37 @@ from re import findall
 import PyInstaller.building.makespec
 
 from src.utils.constants import FIRMWARE_VERSION
+
+_VALID_LEVELS = {"TRACE", "DEBUG", "INFO", "WARN", "WARNING", "ERROR", "CRITICAL"}
+_VERBOSE_LEVELS = {"TRACE", "DEBUG", "INFO"}
+
+
+def _parse_loglevel() -> str:
+    """Read --loglevel from CLI args, fallback to BUILD_LOGLEVEL env var."""
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument(
+        "--loglevel",
+        default=os.environ.get("BUILD_LOGLEVEL", "WARN"),
+        choices=list(_VALID_LEVELS),
+        type=str.upper,
+    )
+    args, _ = parser.parse_known_args()
+    return args.loglevel
+
+
+_LOGLEVEL = _parse_loglevel()
+
+
+def _is_verbose() -> bool:
+    """Return True if loglevel is INFO or below."""
+    return _LOGLEVEL in _VERBOSE_LEVELS
+
+
+def _log(msg: str = "") -> None:
+    """Print only when running in verbose mode."""
+    if _is_verbose():
+        print(msg)
+
 
 if __name__ == "__main__":
     p = argparse.ArgumentParser()
@@ -76,11 +121,11 @@ if __name__ == "__main__":
     # Specifics about operational system
     # on how will behave as file or bundled app
     if SYSTEM == "Linux":
-        # Tha application is a GUI
+        # The application is a GUI
         BUILDER_ARGS.append("--onefile")
 
     elif SYSTEM == "Windows":
-        # Tha application is a GUI with a hidden console
+        # The application is a GUI with a hidden console
         # to keep `sys` module enabled (necessary for Kboot)
         BUILDER_ARGS.append("--onefile")
         BUILDER_ARGS.append("--console")
@@ -88,7 +133,7 @@ if __name__ == "__main__":
         BUILDER_ARGS.append("--hide-console=minimize-early")
 
     elif SYSTEM == "Darwin":
-        # Tha application is a GUI in a bundled .app
+        # The application is a GUI in a bundled .app
         BUILDER_ARGS.append("--onefile")
         BUILDER_ARGS.append("--noconsole")
 
@@ -127,13 +172,29 @@ if __name__ == "__main__":
 
     args = p.parse_args(BUILDER_ARGS)
 
-    # Now generate spec
-    print("============================")
-    print("create-spec.py")
-    print("============================")
-    print()
+    # Print spec summary only when running in verbose mode
+    _log("============================")
+    _log("create-spec.py")
+    _log("============================")
+    _log()
     for k, v in vars(args).items():
-        print(f"{k}: {v}")
+        _log(f"{k}: {v}")
+    _log()
 
-    print()
-    PyInstaller.building.makespec.main(["krux_installer.py"], **vars(args))
+    import os as _os
+
+    if _is_verbose():
+        PyInstaller.building.makespec.main(["krux_installer.py"], **vars(args))
+    else:
+        # PyInstaller writes DEPRECATION warnings directly to the stderr file
+        # descriptor — contextlib.redirect_stderr is not enough. We redirect
+        # fd 2 to /dev/null at the OS level for the duration of this call.
+        devnull_fd = _os.open(_os.devnull, _os.O_WRONLY)
+        old_stderr_fd = _os.dup(2)
+        try:
+            _os.dup2(devnull_fd, 2)
+            PyInstaller.building.makespec.main(["krux_installer.py"], **vars(args))
+        finally:
+            _os.dup2(old_stderr_fd, 2)
+            _os.close(old_stderr_fd)
+            _os.close(devnull_fd)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,8 @@ format = [
 
 fetch-firmware = "python prebuild/fetch_firmware.py"
 
+clean = "python .ci/clean.py"
+
 test-unit = "pytest --cache-clear --cov=src/utils/constants --cov=src/utils/info --cov=src/utils/selector --cov=src/utils/downloader --cov=src/utils/trigger --cov=src/utils/flasher --cov=src/utils/unzip --cov=src/utils/signer --cov=src/utils/verifyer --cov=src/i18n --cov-branch --cov-report html ./tests"
 test-e2e = "pytest --cov-append --cov=src/app --cov-branch --cov-report html ./e2e"
 test-drives = "pytest --cov-append --cov=src/app --cov-branch --cov-report html ./e2e_drives"
@@ -84,27 +86,49 @@ lint.sequence = [
   { cmd = "pylint --rcfile=.pylint/tests ./e2e_drives" },
 ]
 
-build-linux.sequence = [
+# ------------------------------------------------------------
+# Build tasks — all accept an optional --debug flag.
+#
+# Allowed values (case-sensitive, matches PyInstaller levels):
+#   TRACE | DEBUG | INFO | WARN | ERROR | CRITICAL
+#
+# Default is WARN so normal builds stay quiet.
+#
+# The --debug value is passed directly as a CLI argument to the
+# Python build scripts to avoid poe env interpolation issues
+# with sequence tasks.
+#
+# Usage examples:
+#   uv run poe build-macos
+#   uv run poe build-macos --debug=TRACE
+#   uv run poe build-linux --debug=DEBUG
+#   uv run poe build-win   --debug=INFO
+# ------------------------------------------------------------
+
+[tool.poe.tasks.build-linux]
+args = [{ name = "debug", default = "WARN", positional = false }]
+sequence = [
   { cmd = "sh .ci/patch-pyinstaller-kivy-hook.sh" },
-  { cmd = "python .ci/create-spec.py" },
-  { cmd = "python -m PyInstaller krux-installer.spec" },
+  { cmd = "python .ci/create-spec.py --loglevel=${debug}" },
+  { cmd = "python .ci/build.py --loglevel=${debug}" },
 ]
 
-build-macos.sequence = [
+[tool.poe.tasks.build-macos]
+args = [{ name = "debug", default = "WARN", positional = false }]
+sequence = [
   { cmd = "find . -name '.DS_Store' -delete" },
   { cmd = "sh .ci/patch-pyinstaller-kivy-hook.sh" },
-  { cmd = "python .ci/create-spec.py" },
-  { cmd = "python -m PyInstaller krux-installer.spec" },
+  { cmd = "python .ci/create-spec.py --loglevel=${debug}" },
+  { cmd = "python .ci/build.py --loglevel=${debug}" },
 ]
 
-build-win.sequence = [
+[tool.poe.tasks.build-win]
+args = [{ name = "debug", default = "WARN", positional = false }]
+sequence = [
   { cmd = "powershell.exe -File .ci/patch-pyinstaller-kivy-hook.ps1" },
-  { cmd = "python .ci/create-spec.py" },
-  { interpreter = [
-    "powershell",
-    "pwsh",
-  ], shell = "& .ci/edit-spec.ps1" },
-  { cmd = "python -m PyInstaller krux-installer.spec" },
+  { cmd = "python .ci/create-spec.py --loglevel=${debug}" },
+  { interpreter = ["powershell", "pwsh"], shell = "& .ci/edit-spec.ps1" },
+  { cmd = "python .ci/build.py --loglevel=${debug}" },
 ]
 
 [tool.poe.tasks.dev-debug]


### PR DESCRIPTION
fix #238 
- add --debug flag to build-linux, build-macos and build-win poe tasks
  accepted values: TRACE | DEBUG | INFO | WARN | ERROR | CRITICAL
  default is WARN (silent terminal)

- add .ci/build.py: replaces bare `python -m PyInstaller` call
  - runs PyInstaller as subprocess, captures all output
  - routes each line to logs/ by level (trace/debug/info/warn/error)
  - shows spinner on terminal during quiet builds
  - surfaces only real non-noise errors to terminal
  - ASCII fallback for Windows terminal encoding

- add .ci/clean.py: cross-platform cleanup of build/, dist/, logs/ and
.spec

- update .ci/create-spec.py: suppress verbose output unless
--loglevel=INFO or below
  - suppress PyInstaller DEPRECATION warnings via fd2 redirect in quiet
mode

- add logs/ to clean targets