### PR TITLE
fix: add Debian 13 (trixie) support

### DIFF
--- a/e2e/test_002_ask_permission_dialout_screen.py
+++ b/e2e/test_002_ask_permission_dialout_screen.py
@@ -650,3 +650,22 @@ class TestAskPermissionDialoutScreen(GraphicUnitTest):
 
         open_mock.assert_called()
         mock_get_locale.assert_called_once()
+
+    @patch.object(EventLoopBase, "ensure_window", lambda x: None)
+    @patch(
+        "src.app.screens.base_screen.BaseScreen.get_locale", return_value="en_US.UTF-8"
+    )
+    @patch(
+        "src.app.screens.ask_permission_dialout_screen.open",
+        new_callable=mock_open,
+        read_data="ID=mockos\nPRETTY_NAME=MockOS",
+    )
+    @patch(
+        "src.app.screens.ask_permission_dialout_screen.AskPermissionDialoutScreen.redirect_exception"
+    )
+    def test_detect_usermod_bin_unsupported(
+        self, mock_redirect_exception, _open_mock, mock_get_locale
+    ):
+        AskPermissionDialoutScreen()
+        mock_get_locale.assert_called()
+        mock_redirect_exception.assert_called_once()

--- a/src/app/screens/ask_permission_dialout_screen.py
+++ b/src/app/screens/ask_permission_dialout_screen.py
@@ -125,8 +125,11 @@ class AskPermissionDialoutScreen(BaseScreen):
             # Default path if not identified
             bin_path = "/usr/sbin/usermod"
 
-            # Check for Debian-based systems (PopOS, Ubuntu, Linux Mint, etc.)
-            if "ID_LIKE" in os_data and "debian" in os_data["ID_LIKE"]:
+            # Check for Debian and Debian-based systems (PopOS, Ubuntu, Linux Mint, etc.)
+            # On non-standard derivative, check for both "ID" and "ID_LIKE"
+            if os_data.get("ID") == "debian" or (
+                "ID_LIKE" in os_data and "debian" in os_data["ID_LIKE"]
+            ):
                 bin_path = "/usr/sbin/usermod"
 
             # Check for Red Hat-based systems (Fedora, CentOS, Rocky Linux, etc.)
@@ -142,7 +145,7 @@ class AskPermissionDialoutScreen(BaseScreen):
             elif "ID" in os_data and "fedora" in os_data["ID"]:
                 bin_path = "/usr/sbin/usermod"
 
-            # Arch, Artix, Manjaro, Slackware, Gentoo,
+            # Arch, Artix, Manjaro, Slackware, Gentoo
             elif os_data.get("ID") in (
                 "arch",
                 "artix",
@@ -155,12 +158,12 @@ class AskPermissionDialoutScreen(BaseScreen):
             # For Alpine, Clear Linux, Solus, etc.
             elif os_data.get("ID") in ("alpine", "clear-linux", "solus"):
                 bin_path = "/usr/bin/usermod"
+
             # For NixOS
             elif os_data.get("ID") == "nixos":
                 bin_path = "/run/current-system/sw/bin/usermod"
 
             else:
-                # Default to /usr/sbin/usermod if no match is found
                 exc = RuntimeError(
                     f"Unrecognized distro: {os_data.get('PRETTY_NAME', 'Unknown')}"
                 )

--- a/src/app/screens/greetings_screen.py
+++ b/src/app/screens/greetings_screen.py
@@ -99,10 +99,13 @@ class GreetingsScreen(BaseScreen):
                 if "=" in line
             }
 
-            # Check for Debian-like systems (PopOS, Ubuntu, Linux Mint, etc.)
-            if "ID_LIKE" in os_data and "debian" in os_data["ID_LIKE"]:
+            # Check for Debian and Debian-based systems (PopOS, Ubuntu, Linux Mint, etc.)
+            # On non-standard derivative, check for both "ID" and "ID_LIKE"
+            if os_data.get("ID") == "debian" or (
+                "ID_LIKE" in os_data and "debian" in os_data["ID_LIKE"]
+            ):
                 detected = (
-                    os_data["ID_LIKE"],
+                    os_data.get("ID") or os_data.get("ID_LIKE"),
                     "dialout",
                 )
 


### PR DESCRIPTION
Closes #197

Debian does not set ID_LIKE like its derivatives, so it was never matched and crashed on startup. Also fixed redirect_exception to not crash when self.manager is None.

Also noticed both methods duplicate the same distro detection logic, happy to
refactor if thats of interest. :)