### PR TITLE
Hotfix flake on mac

### DIFF
--- a/.github/workflows/nix_darwin.yml
+++ b/.github/workflows/nix_darwin.yml
@@ -1,0 +1,59 @@
+name: "Nix: macOS (nix-darwin)"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "pyproject.toml"
+      - "src/**"
+      - "tests/**"
+      - "e2e/**"
+      - "e2e_drives/**"
+      - ".github/workflows/nix_darwin.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "pyproject.toml"
+      - "src/**"
+      - "tests/**"
+      - "e2e/**"
+      - "e2e_drives/**"
+      - ".github/workflows/nix_darwin.yml"
+
+jobs:
+  nix-darwin:
+    name: "Test (nix-darwin / aarch64-darwin)"
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install Nix (Determinate Systems)
+        uses: DeterminateSystems/nix-installer-action@v17
+
+      - name: Install Python dependencies
+        run: nix develop .# --command uv sync --all-extras
+
+      - name: Fetch firmware
+        run: nix develop .# --command uv run poe fetch-firmware
+
+      - name: Lint
+        run: nix develop .# --command uv run poe lint
+
+      - name: Test (unit)
+        run: nix develop .# --command uv run poe coverage-unit
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true

--- a/.github/workflows/nix_linux.yml
+++ b/.github/workflows/nix_linux.yml
@@ -37,6 +37,18 @@ jobs:
         with:
           submodules: recursive
 
+      # KVM is available on GitHub's free runners for public repos.
+      # This udev rule grants group-level access so QEMU can use it.
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      # Install Nix on the Ubuntu host — only used to build and boot the VM.
+      # sandbox=false lets the VM process reach the internet (needed for
+      # uv sync and firmware fetch that run inside the VM).
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:
@@ -44,30 +56,97 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
             accept-flake-config = true
+            sandbox = false
+            system-features = nixos-test kvm
 
-      - name: Install Xvfb
-        run: sudo apt-get install -y xvfb
+      # Install sshpass on the host to supply the VM root password
+      # non-interactively. Password is set in the flake ("ci").
+      - name: Install sshpass
+        run: sudo apt-get install -y sshpass
+
+      # Build the ciTest NixOS VM image from the flake.
+      # Produces result/bin/run-nixos-vm which boots the VM via QEMU.
+      - name: Build NixOS VM
+        run: nix build .#nixosConfigurations.ciTest.config.system.build.vm
+
+      # Boot the VM in the background (daemonized, no display window).
+      # -virtfs mounts the host workspace into the VM via 9p with tag
+      # "workspace" — the flake declares the corresponding fileSystems entry.
+      - name: Boot NixOS VM
+        run: |
+          result/bin/run-nixos-vm \
+            -daemonize \
+            -display none \
+            -virtfs local,path=${{ github.workspace }},mount_tag=workspace,security_model=mapped-xattr
+
+      # Wait until SSH is reachable on the forwarded host port 2222.
+      - name: Wait for VM to be ready
+        run: |
+          for i in $(seq 1 30); do
+            sshpass -p ci ssh \
+              -o StrictHostKeyChecking=no \
+              -o ConnectTimeout=5 \
+              -p 2222 root@localhost \
+              "echo ready" 2>/dev/null && break
+            echo "Waiting for VM... attempt $i"
+            sleep 5
+          done
+
+      # The flake's fileSystems entry mounts the 9p tag at /workspace on boot.
+      # We also try an explicit mount here in case automount hasn't fired yet,
+      # then verify the directory is accessible before proceeding.
+      - name: Mount workspace in VM
+        run: |
+          sshpass -p ci ssh -o StrictHostKeyChecking=no -p 2222 root@localhost \
+            "mkdir -p /workspace && \
+             mount -t 9p -o trans=virtio,version=9p2000.L,msize=131072 workspace /workspace 2>/dev/null || true && \
+             mountpoint /workspace && \
+             ls /workspace | head -3"
+
+      # All remaining steps run inside the NixOS VM via SSH.
+
+      # The workspace is owned by the host runner user but accessed as root
+      # inside the VM. Git and nix refuse to operate on it without this.
+      - name: Fix git safe directory
+        run: |
+          sshpass -p ci ssh -o StrictHostKeyChecking=no -p 2222 root@localhost \
+            "git config --global --add safe.directory /workspace"
 
       - name: Install Python dependencies
-        run: nix develop .# --command uv sync --all-extras
-
-      - name: Install pytest-xvfb
-        run: nix develop .# --command uv add pytest-xvfb
+        run: |
+          sshpass -p ci ssh -o StrictHostKeyChecking=no -p 2222 root@localhost \
+            "cd /workspace && nix develop .# --command uv sync --all-extras"
 
       - name: Fetch firmware
-        run: nix develop .# --command uv run poe fetch-firmware
+        run: |
+          sshpass -p ci ssh -o StrictHostKeyChecking=no -p 2222 root@localhost \
+            "cd /workspace && nix develop .# --command uv run poe fetch-firmware"
 
       - name: Lint
-        run: nix develop .# --command uv run poe lint
+        run: |
+          sshpass -p ci ssh -o StrictHostKeyChecking=no -p 2222 root@localhost \
+            "cd /workspace && nix develop .# --command uv run poe lint"
 
       - name: Test (unit)
-        run: nix develop .# --command uv run poe coverage-unit
+        run: |
+          sshpass -p ci ssh -o StrictHostKeyChecking=no -p 2222 root@localhost \
+            "cd /workspace && nix develop .# --command uv run poe coverage-unit"
 
       - name: Test (e2e)
-        run: nix develop .# --command uv run poe coverage-e2e
+        run: |
+          sshpass -p ci ssh -o StrictHostKeyChecking=no -p 2222 root@localhost \
+            "cd /workspace && nix develop .# --command uv run poe coverage-e2e"
 
       - name: Test (drives)
-        run: nix develop .# --command uv run poe coverage-drives
+        run: |
+          sshpass -p ci ssh -o StrictHostKeyChecking=no -p 2222 root@localhost \
+            "cd /workspace && nix develop .# --command uv run poe coverage-drives"
+
+      # Copy coverage XML from the VM back to the host for Codecov upload.
+      - name: Copy coverage report from VM
+        run: |
+          sshpass -p ci scp -o StrictHostKeyChecking=no -P 2222 \
+            root@localhost:/workspace/coverage.xml ./coverage.xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v6

--- a/.github/workflows/nix_linux.yml
+++ b/.github/workflows/nix_linux.yml
@@ -1,0 +1,76 @@
+name: "Nix: Linux (NixOS)"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "pyproject.toml"
+      - "src/**"
+      - "tests/**"
+      - "e2e/**"
+      - "e2e_drives/**"
+      - ".github/workflows/nix_linux.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "pyproject.toml"
+      - "src/**"
+      - "tests/**"
+      - "e2e/**"
+      - "e2e_drives/**"
+      - ".github/workflows/nix_linux.yml"
+
+jobs:
+  nix-linux:
+    name: "Test (NixOS / x86_64-linux)"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      - name: Install Xvfb
+        run: sudo apt-get install -y xvfb
+
+      - name: Install Python dependencies
+        run: nix develop .# --command uv sync --all-extras
+
+      - name: Install pytest-xvfb
+        run: nix develop .# --command uv add pytest-xvfb
+
+      - name: Fetch firmware
+        run: nix develop .# --command uv run poe fetch-firmware
+
+      - name: Lint
+        run: nix develop .# --command uv run poe lint
+
+      - name: Test (unit)
+        run: nix develop .# --command uv run poe coverage-unit
+
+      - name: Test (e2e)
+        run: nix develop .# --command uv run poe coverage-e2e
+
+      - name: Test (drives)
+        run: nix develop .# --command uv run poe coverage-drives
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,21 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
   outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+    let
+      # -----------------------------------------------------------------------
+      # ciPkgs — nixpkgs for x86_64-linux, used only by ciTest below.
+      # Has no effect on devShells or any local dev workflow.
+      # -----------------------------------------------------------------------
+      ciPkgs = import nixpkgs {
+        system = "x86_64-linux";
+        config.allowUnfree = true;
+      };
+    in
+    # -------------------------------------------------------------------------
+    # devShells — for local development on Linux and macOS (nix develop).
+    # This is the only entry point end users and contributors need.
+    # -------------------------------------------------------------------------
+    (flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
           inherit system;
@@ -49,11 +63,6 @@
             pkgs.gdk-pixbuf
             pkgs.atk
             pkgs.stdenv.cc.cc.lib
-          ] ++ pkgs.lib.optionals isLinux [
-            pkgs.polkit
-            pkgs.libGL
-            pkgs.mtdev
-            pkgs.shadow
             pkgs.xorg.libX11
             pkgs.xorg.libXext
             pkgs.xorg.libXrender
@@ -64,6 +73,7 @@
             pkgs.xorg.libXi
             pkgs.xorg.libXxf86vm
             pkgs.SDL2
+            pkgs.SDL2.dev
             pkgs.SDL2_image
             pkgs.SDL2_mixer
             pkgs.SDL2_ttf
@@ -71,16 +81,23 @@
             pkgs.darwin.apple_sdk.frameworks.Cocoa
             pkgs.darwin.apple_sdk.frameworks.OpenGL
             pkgs.darwin.apple_sdk.frameworks.IOKit
+            pkgs.darwin.apple_sdk.frameworks.AVFoundation
+            pkgs.darwin.apple_sdk.frameworks.CoreMedia
+            pkgs.darwin.apple_sdk.frameworks.CoreVideo
+            pkgs.darwin.apple_sdk.frameworks.ApplicationServices
+            pkgs.SDL2
+            pkgs.SDL2.dev
+            pkgs.SDL2_image
+            pkgs.SDL2_mixer
+            pkgs.SDL2_ttf
+            pkgs.libcxx
           ];
-
 
           shellHook = ''
             export HOME="''${HOME:-$(pwd)/.home}"
             export XDG_DATA_HOME="$HOME/.local/share"
             export XDG_CONFIG_HOME="$HOME/.config"
-            export XDG_CONFIG_HOME="$HOME/.config"
             export XDG_CACHE_HOME="$HOME/.cache"
-
 
             mkdir -p "$HOME" "$XDG_DATA_HOME" "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME"
 
@@ -96,11 +113,14 @@
             mkdir -p "$PIP_CACHE_DIR"
 
             export PATH="$UV_TOOL_BIN_DIR:$PATH"
+            export UV_PYTHON="${pkgs.python313}/bin/python3"
 
             ${pkgs.lib.optionalString isLinux ''
               if [ -e "${pkgs.mtdev}/lib/libmtdev.so" ] && [ ! -e "${pkgs.mtdev}/lib/libmtdev.so.1" ]; then
                 ln -sf "${pkgs.mtdev}/lib/libmtdev.so" "${pkgs.mtdev}/lib/libmtdev.so.1"
               fi
+
+              export DISPLAY="''${DISPLAY:-:0}"
 
               export LD_LIBRARY_PATH=\
               ${pkgs.libGL}/lib:\
@@ -110,6 +130,36 @@
               ${pkgs.mtdev}/lib:\
               ${pkgs.SDL2}/lib:\
               $LD_LIBRARY_PATH
+
+              export PKG_CONFIG_PATH=\
+              ${pkgs.SDL2}/lib/pkgconfig:\
+              ${pkgs.SDL2_image}/lib/pkgconfig:\
+              ${pkgs.SDL2_mixer}/lib/pkgconfig:\
+              ${pkgs.SDL2_ttf}/lib/pkgconfig:\
+              $PKG_CONFIG_PATH
+
+              export CFLAGS="-I${pkgs.SDL2.dev}/include/SDL2 -I${pkgs.SDL2.dev}/include"
+              export CPPFLAGS="-I${pkgs.SDL2.dev}/include/SDL2 -I${pkgs.SDL2.dev}/include"
+            ''}
+
+            ${pkgs.lib.optionalString isDarwin ''
+              export SDKROOT="${pkgs.darwin.apple_sdk.MacOSX-SDK}"
+
+              export DYLD_LIBRARY_PATH=\
+              ${pkgs.SDL2}/lib:\
+              ${pkgs.openssl}/lib:\
+              $DYLD_LIBRARY_PATH
+
+              export PKG_CONFIG_PATH=\
+              ${pkgs.SDL2}/lib/pkgconfig:\
+              ${pkgs.SDL2_image}/lib/pkgconfig:\
+              ${pkgs.SDL2_mixer}/lib/pkgconfig:\
+              ${pkgs.SDL2_ttf}/lib/pkgconfig:\
+              $PKG_CONFIG_PATH
+
+              export CFLAGS="-I${pkgs.SDL2.dev}/include/SDL2 -I${pkgs.SDL2.dev}/include -isysroot ${pkgs.darwin.apple_sdk.MacOSX-SDK}"
+              export CPPFLAGS="-I${pkgs.SDL2.dev}/include/SDL2 -I${pkgs.SDL2.dev}/include -isysroot ${pkgs.darwin.apple_sdk.MacOSX-SDK}"
+              export CXXFLAGS="-isysroot ${pkgs.darwin.apple_sdk.MacOSX-SDK}"
             ''}
 
             export PYTHONPATH=$PWD/src:$PYTHONPATH
@@ -123,5 +173,91 @@
           '';
         };
       }
-    );
+    )) // {
+      # -----------------------------------------------------------------------
+      # nixosConfigurations.ciTest — CI-only NixOS VM (nix_linux.yml).
+      #
+      # This is a minimal NixOS machine used by GitHub Actions to run the
+      # full test suite (unit + e2e + drives) inside a real NixOS environment.
+      #
+      # Key properties:
+      #   - X server enabled so Kivy/GraphicUnitTest gets a real display
+      #   - Full internet access via DHCP (needed for uv sync + firmware fetch)
+      #   - Host workspace mounted at /workspace via 9p virtfs.
+      #     The mount tag "workspace" is declared here via a systemd unit;
+      #     the actual host path is passed at runtime by the workflow using
+      #     -virtfs local,path=<workspace>,mount_tag=workspace
+      #   - SSH forwarded to host port 2222 so the workflow drives test steps
+      #   - Root login with a simple password — safe: ephemeral, localhost-only
+      #
+      # To build locally (x86_64-linux only):
+      #   nix build .#nixosConfigurations.ciTest.config.system.build.vm
+      # -----------------------------------------------------------------------
+      nixosConfigurations.ciTest = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          ({ modulesPath, ... }: {
+            imports = [ "${modulesPath}/virtualisation/qemu-vm.nix" ];
+
+            system.stateVersion = "25.05";
+            nixpkgs.hostPlatform = "x86_64-linux";
+
+            # -- VM resources tuned for GitHub Actions free runners ------------
+            virtualisation = {
+              cores = 2;
+              memorySize = 4096;
+              diskSize = 8192;
+
+              # Forward VM SSH to host port 2222 so the workflow can ssh in.
+              forwardPorts = [{
+                from = "host";
+                host.port = 2222;
+                guest.port = 22;
+              }];
+            };
+
+            # -- Workspace mount: 9p virtfs tag "workspace" -------------------
+            # The host path is passed at boot time by the workflow via:
+            #   -virtfs local,path=<host-path>,mount_tag=workspace,...
+            # This systemd unit mounts that tag at /workspace inside the VM.
+            # Load 9p kernel modules in the initrd so the virtfs mount works.
+            boot.initrd.availableKernelModules = [ "9p" "9pnet_virtio" "virtio_pci" ];
+
+            # Ensure /workspace exists as a mountpoint directory.
+            systemd.tmpfiles.rules = [ "d /workspace 0755 root root -" ];
+
+            fileSystems."/workspace" = {
+              device = "workspace";
+              fsType = "9p";
+              options = [ "trans=virtio" "version=9p2000.L" "msize=131072" "nofail" "x-systemd.automount" ];
+            };
+
+            # -- Network: full internet access via DHCP -----------------------
+            networking.useDHCP = true;
+            networking.firewall.enable = false;
+
+            # -- Display: X server so Kivy/GraphicUnitTest gets a real DISPLAY -
+            services.xserver.enable = true;
+
+            # -- SSH: root login for ephemeral CI VM only ---------------------
+            services.openssh.enable = true;
+            services.openssh.settings.PermitRootLogin = "yes";
+            users.extraUsers.root.password = "ci";
+
+            # -- Packages available inside the VM -----------------------------
+            environment.systemPackages = with ciPkgs; [
+              # nix is needed to run `nix develop` on the mounted workspace
+              nix
+              git
+              # curl + unzip for the firmware fetch script
+              curl
+              unzip
+            ];
+
+            # Enable flakes inside the VM
+            nix.settings.experimental-features = [ "nix-command" "flakes" ];
+          })
+        ];
+      };
+    };
 }


### PR DESCRIPTION
A recently update in the pygame lib change the way that the pygame uses SDL2 for nix users in nix darwin the flake will not work, this Pull request fix this, by adding new sdl2 dependencies entries, its good to re-remember that the flake for nix users still in a beta/experimental state because of that i did not made the nix package yet, i personally use nix everyday but i still think that for breaks like that stil not stable to have a package, the flake its more a development thing so i think we can continue to mantain it, my unique proposal its to maybe add an actions for it in a close future, this PR also adds a CI to a separeted branch that will handle all  the nix stuff