### PR TITLE
docs: add `SECURITY.md`

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# SECURITY policy
+
+Please report any vulnerability on any bug that could potentially affect the
+security of user's funds by mail to [`qlrddev@proton.me`](mailto:qlrddev@proton.me).
+
+Additionally, you could send a copy to [`joaomcr@proton.me`](mailto:joaomcr@proton.me).
+
+You may use PGP encryption and signing. The public keys can be found [here](https://github.com/qlrd.gpg)
+and [here](https://github.com/joaozinhom.gpg).
+
+In the subject type, please type `[Krux-installer] Security Report: <short description>`
+and in the body a long description describing the issue. We aim to respond within
+one week and patch within 90 days.


### PR DESCRIPTION
This commit adds a `SECURITY.md` simple guide for security reporting.