### PR TITLE
chore(uv): migrate dev dependencies to dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,8 @@ build-backend = "hatchling.build"
 [tool.hatch.metadata]
 allow-direct-references = true
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "black>=26.5.1",
     "pylint>=4.0.6",
     "pytest-cov>=7.1.0",


### PR DESCRIPTION
## Summary

- replace the deprecated `tool.uv.dev-dependencies` field with the standardized `dependency-groups.dev` table
- preserve all six development requirements and their order
- keep the published `project.optional-dependencies.dev` extra unchanged
- leave `uv.lock` unchanged

Closes #290

## Validation

- `uv lock --check` (without the legacy-field warning)
- `uv sync --all-extras --locked`
- `uv tree --group dev`
- `uv run poe lint`
- `uv run poe test-unit` — 111 passed, 8 skipped
- all four CI Black checks