### PR TITLE
chore: add pre-commit poe task

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,11 @@ Run formatting, linting and tests together:
 uv run poe pre-commit
 ```
 
+Running this locally mirrors the core CI code checks, except for commit message
+format and changelog requirements. It helps prevent failed PR builds and ensures
+that changes follow the [contribution guidelines](./CONTRIBUTING.md). Depending
+on the change, a [changelog](./CHANGELOG.md) entry may also be required.
+
 ### Format code
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -176,6 +176,14 @@ coverage and build.
 uv run poe
 ```
 
+### Before committing
+
+Run formatting, linting and tests together:
+
+```bash
+uv run poe pre-commit
+```
+
 ### Format code
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,8 @@ lint.sequence = [
   { cmd = "pylint --rcfile=.pylint/tests ./e2e_drives" },
 ]
 
+pre-commit = ["format", "lint", "test"]
+
 # ------------------------------------------------------------
 # Build tasks — all accept an optional --debug flag.
 #


### PR DESCRIPTION
## Summary

- add a single Poe task that runs the existing format, lint, and test tasks in order
- document `uv run poe pre-commit` in the development workflow

Closes #293

## Testing

- `uv run poe --dry-run pre-commit`
- `uv run poe pre-commit`
  - formatting, Markdown/JSON checks, and Pylint passed
  - 119 unit tests passed
  - 241 end-to-end tests passed
  - 8 drive tests passed
- `uv lock --check`
- `git diff --check`

## AI assistance

Implemented with OpenAI Codex assistance and independently reviewed against the current repository contracts.