### PR TITLE
docs: use frozen uv sync commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ git clone --recurse-submodules https://github.com/selfcustody/krux-installer.git
 Install python dependencies:
 
 ```bash
-uv sync
+uv sync --frozen
 ```
 
 ## Update code
@@ -212,7 +212,7 @@ You can see all coverage results opening you browser and type
 ### Build for any Linux distribution
 
 ```bash
-uv sync --extra builder
+uv sync --frozen --extra builder
 uv run poe fetch-firmware
 uv run poe build-linux
 ```
@@ -220,7 +220,7 @@ uv run poe build-linux
 ### Build for MacOS
 
 ```bash
-uv sync --extra builder
+uv sync --frozen --extra builder
 uv run poe fetch-firmware
 uv run poe build-macos
 ```
@@ -228,7 +228,7 @@ uv run poe build-macos
 ### Build for Windows
 
 ```bash
-uv sync --extra builder
+uv sync --frozen --extra builder
 uv run poe fetch-firmware
 uv run poe build-win
 ```
@@ -287,7 +287,7 @@ at build time.
 ### Fetching official firmware
 
 ```bash
-uv sync --extra builder
+uv sync --frozen --extra builder
 uv run poe fetch-firmware
 ```
 


### PR DESCRIPTION
## Summary

- add `--frozen` to the dependency setup command
- use frozen syncs for build and firmware-fetching instructions

Closes #292.

## Verification

- `uv sync --frozen --dry-run --python 3.13`
- `uv sync --frozen --extra builder --dry-run --python 3.13`
- `pymarkdownlnt -d MD013,MD033,MD036 -e MD024 scan README.md`
- `git diff --check`