### PR TITLE
fix(ci): retry NSIS after transient Chocolatey failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,10 +156,20 @@ jobs:
         id: release-windows
         shell: pwsh
         run: |
-          choco install nsis -y
           $nsisPath = "C:\Program Files (x86)\NSIS\makensis.exe"
-          if (-not (Test-Path $nsisPath)) {
-            throw "NSIS not found at expected location: $nsisPath"
+          $maxAttempts = 3
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            choco install nsis --yes --no-progress --ignore-http-cache
+            $chocoExitCode = $LASTEXITCODE
+            if (Test-Path -LiteralPath $nsisPath) {
+              break
+            }
+            if ($attempt -eq $maxAttempts) {
+              throw "NSIS installation failed after $maxAttempts attempts. Last Chocolatey exit code: $chocoExitCode; expected executable: $nsisPath"
+            }
+            $delaySeconds = 15 * $attempt
+            Write-Warning "NSIS installation attempt $attempt failed (Chocolatey exit code: $chocoExitCode). Retrying in $delaySeconds seconds..."
+            Start-Sleep -Seconds $delaySeconds
           }
           Write-Host "Found NSIS at: $nsisPath"
           New-Item ".\release" -Type Directory -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Why

The Windows release job occasionally stops at `choco install nsis` when the Chocolatey community feed is temporarily unavailable. Because the job needs `makensis.exe` later, that transient download failure prevents the entire Windows build from completing. This addresses #300 without changing the Linux or macOS jobs.

## What changed

- retry the Chocolatey NSIS installation up to three times
- use `--ignore-http-cache` so each retry fetches fresh HTTP metadata instead of repeating a failure from stale metadata
- stop retrying as soon as `makensis.exe` is present
- report the last Chocolatey exit code and expected executable path after the final failed attempt

Closes #300.

## Verification

- parsed the workflow YAML
- parsed the Windows step with the PowerShell parser
- `actionlint .github/workflows/build.yml`
- simulated first-attempt success, retry success, and final failure
- `git diff --check`

## AI-assisted development

This PR was prepared with the Codex desktop client using GPT-5.6 Sol with high reasoning. The model assisted with implementation and validation. This use is disclosed here and in the commit's `Co-authored-by` trailer, following the discussion in #294.