### PR TITLE
chore: updates to new release of krux-installer to get krux 26.09

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,26 @@
 # CHANGELOG
 
-## Unreleased
+## 0.0.24
 
+- Embedded firmware bumped to `v26.09.0` (`prebuild/fetch_firmware.sh` and
+  `FIRMWARE_VERSION` in `src/utils/constants/__init__.py`);
 - Removed the entire runtime download pipeline left over from the online workflow, now that firmware is embedded at build time:
-  - download screens (`base_download_screen`, `download_stable_zip_screen`, `download_beta_screen`), version selection screens (`select_version_screen`, `select_old_version_screen`) and the `warning_beta` / `warning_already_downloaded` / `unzip_stable` screens`;
+  - download screens (`base_download_screen`, `download_stable_zip_screen`, `download_beta_screen`), version selection screens (`select_version_screen`, `select_old_version_screen`) and the `warning_beta` / `warning_already_downloaded` / `unzip_stable` screens;
   - `downloader`, `selector` and `unzip` utils, plus the `check_verifyer`;
   - the associated unit and E2E tests and their orphaned i18n strings;
-- With this cleanup the installer makes **no network calls at runtime** and no longer checks the internet connection on startup — the user flow is now just: open the installer, select a device and flash.
+- With this cleanup the installer makes **no network calls at runtime** and no longer checks the internet connection on startup — the user flow is now just: open the installer, select a device and flash;
+- Added `SECURITY.md` with the supported versions and the vulnerability
+  reporting process;
+- Added the mission-hardening disclaimer to the greetings screen;
+- Added pre-commit hooks running the `poe` quality tasks, so the same checks
+  CI runs happen before a commit is made;
+- Migrated dev dependencies to a `uv` dependency group and documented the
+  frozen `uv sync` commands;
+- Fixed Dependabot picking a release that a later patch release had already
+  fixed;
+- CI now retries the NSIS install after transient Chocolatey failures;
+- Bumped `cryptography` to 50.0.1, `pylint` to 4.0.7, `pymarkdownlnt` to
+  0.9.39 and `actions/setup-python` to 7.
 
 ## 0.0.23
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Instead, each release ships with a single firmware version already embedded, ver
 ### Choosing a firmware version
 
 Each release ships with a fixed firmware version embedded in the binary
-(the current one is `v26.03.0`). To flash a different firmware version,
+(the current one is `v26.09.0`). To flash a different firmware version,
 download the installer release that bundles it, or build from source with
 your desired version (see [Firmware embedding (for developers)](/#firmware-embedding-for-developers)).
 

--- a/prebuild/fetch_firmware.sh
+++ b/prebuild/fetch_firmware.sh
@@ -39,7 +39,7 @@ set -euo pipefail
 # ── Configuration ────────────────────────────────────────────────────────────
 ALLOW_UNVERIFIED=0
 VERIFICATION_SKIPPED=0
-FIRMWARE_VERSION="v26.08.0"
+FIRMWARE_VERSION="v26.09.0"
 BASE_URL="https://github.com/selfcustody/krux/releases/download/${FIRMWARE_VERSION}"
 ZIP_NAME="krux-${FIRMWARE_VERSION}.zip"
 SHA256_NAME="${ZIP_NAME}.sha256.txt"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "krux-installer"
-version = "0.0.23"
+version = "0.0.24"
 description = "A GUI based application to flash Krux firmware on K210 based devices"
 authors = [
-    {name = "qlrd", email = "qlrddev@gmail.com"},
+    {name = "qlrd", email = "qlrddev@proton.me"},
     {name = "joaozinhom", email = "joaomcr@proton.me"}
 ]
 license = {text = "MIT"}

--- a/src/utils/constants/__init__.py
+++ b/src/utils/constants/__init__.py
@@ -33,7 +33,7 @@ from typing import Any, Dict, List
 
 ROOT_DIRNAME = os.path.abspath(os.path.dirname(__file__))
 
-FIRMWARE_VERSION = "v26.08.0"
+FIRMWARE_VERSION = "v26.09.0"
 
 FIRMWARE_DIR = os.path.abspath(
     os.path.join(ROOT_DIRNAME, "..", "firmware", FIRMWARE_VERSION)

--- a/uv.lock
+++ b/uv.lock
@@ -725,7 +725,7 @@ wheels = [
 
 [[package]]
 name = "krux-installer"
-version = "0.0.23"
+version = "0.0.24"
 source = { editable = "." }
 dependencies = [
     { name = "easy-i18n" },


### PR DESCRIPTION
update  docs, prebuild/fetch_firmware and constants/__init__.py file to be compliant with the new krux release and to we can launch the new release of the installer.